### PR TITLE
don't error on use-before-define if it's a function name

### DIFF
--- a/loose.json
+++ b/loose.json
@@ -27,6 +27,7 @@
         "no-bitwise": 2,
         "no-trailing-spaces": 1,
         "no-underscore-dangle": 0,
+        "no-use-before-define": [2, "nofunc"],
         "no-multi-spaces": [1, {"exceptions": {
             "AssignmentExpression": true,
             "BinaryExpression": true,

--- a/strict.json
+++ b/strict.json
@@ -26,6 +26,7 @@
         "indent": [1, 4, {"indentSwitchCase": true}],
         "key-spacing": 0,
         "max-len": [1, 120, 4],
+        "no-use-before-define": [2, "nofunc"],
         "no-bitwise": 2,
         "no-console": 1,
         "no-debugger": 1,


### PR DESCRIPTION
this is no longer an error:

```
function mainWork(){
    _helperMethod();
}

function _helperMethod(){
    // super helpful
}
```

helps keep files readable by putting the most important stuff in the file first.  only applies for function name hoisting.
