### PR TITLE
Add dangling comma eslint rule

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -17,7 +17,7 @@
         "semi": [1, "never"],
         "quotes": [1, "single", "avoid-escape"],
         "camelcase": [2, {"properties": "never"}],
-        "comma-dangle": [1, "never"],
+        "comma-dangle": [2, "always-multiline"],
         "comma-spacing": 1,
         "curly": [2, "multi-line"],
         "dot-notation": 0,


### PR DESCRIPTION
I'm not sure if it's too early to start requesting some changes to the `.eslint` config, but this one is screaming for me to submit a PR. Basically, dangling commas let you keep pull request diffs to the minimum and also prevent refactoring errors when moving around / modifying object literal properties...

``` javascript
const object = {
  bProperty: 'hey!',
  aProperty: 12
}
```

If I wanted to be a good guy and alphabetize these object properties, I **must** change both property lines of code, removing the comma from one and adding it to the other...

``` javascript
const object = {
  aProperty: 12, // <- added
  bProperty: 'hey!' // <- removed
}
```

This is a fairly easy error to miss. In addition, if I then wanted to add a property, I'll have to modify **two** lines of code, which makes the diff noisier and also is error-prone

``` javascript
const object = {
  aProperty: 12, 
  bProperty: 'hey!', // <- Add a comma here,
  cProperty: 'new'
}
```

If we turn dangling commas on, every object's last property needs a comma, which makes rearranging / adding properties trivial and keeps our diffs much cleaner. Note that this rule is annoying for single-line object declarations, so I've asked to se the rule to `always-multiline`.

``` javascript
const object = {
  aProperty: 12, 
  bProperty: 'hey!',
  cProperty: 'new', // <- Hooray! Dangling comma
}
```
